### PR TITLE
Add food bank API documentation 

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,8 +50,168 @@ urls = (
 
 class index:
 	def GET(self):
-		return "Hello! This is an API that gives information on nearby foodbanks and the items they need. Check out the documentation, when it exists..."
+		return "Hello! This is an API that gives information on nearby food banks and the items they need. Check out the documentation, when it exists..."
 
+class documentation:
+	def GET(self):
+		return 
+	<!DOCTYPE html>
+<html>
+<body>
+
+<h1 id="Foodbank API">Foodbank API</h1>
+<p>Contains information about individual food items needed by a Trussell Trust food bank specified by name or location. 
+
+<h2 id="Base URL">Base URL</h2>
+<p>http://whatfoodbanksneed.org.uk</p>
+
+<h3 id="Endpoint 1">Endpoint 1</h3>
+<p>GET /Individual_foodbank_information</p>
+
+<h4 id="Description">Description</h4>
+<p>This returns the food bank name and the food items needed for the named food bank.</p>
+
+<h4 id="Query string parameters">Query string parameters</h4>
+
+<head>
+<style>
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+</style>
+</head>
+<body>
+
+<table style="width:100%">
+  <tr>
+    <th>Query string parameter</th>
+    <th>Required/optional</th> 
+    <th>Description</th>
+    <th>Type</th>
+  </tr>
+  <tr>
+    <td>foodbank_name</td>
+    <td>Required</td> 
+    <td>Name of food bank</td>
+    <td>string</td>
+  </tr>
+</table>
+
+<h4 id="Response">Response</h4>
+
+<table style="width:100%">
+  <tr>
+    <th>Field</th>
+    <th>Description</th> 
+    <th>Data type</th>
+    <th>Example</th>
+  </tr>
+  <tr>
+    <td>foodbank_name</td>
+    <td>Name of food bank</td> 
+    <td>String</td>
+    <td>"Mid Norfolk Foodbank"</td>
+  </tr>
+   <tr>
+    <td>Items_needed</td>
+    <td>List of food items needed for specified food bank</td> 
+    <td>array [string]</td>
+    <td>"tinned fruit", "tinned rice pudding"</td>
+  </tr>
+</table>
+
+<h4 id="Input error">Input error</h4>
+<p>If the food bank doesn't exist, it will return the following string:
+<blockquote>"This food bank isn't in our database, sorry."</blockquote></p>
+
+<h3 id="Endpoint 2">Endpoint 2</h3>
+<p>GET /nearest_foodbanks</p>
+
+<h4 id="Description">Description</h4>
+Returns information about food banks near to your specified location in ascending order of distance, which includes food bank name, distance to inputted location in miles, food bank address, food bank website and food items needed.
+
+<h4 id="Query string parameters">Query string parameters</h4>
+
+<table style="width:100%">
+  <tr>
+    <th>Query string parameter</th>
+    <th>Required/optional</th> 
+    <th>Description</th>
+    <th>Type</th>
+  </tr>
+  <tr>
+    <td>Latitude</td>
+    <td>Required</td> 
+    <td>Latitude of the search area [needs range of numbers that will be supported]</td>
+    <td>Decimal</td>
+  </tr>
+   <tr>
+    <td>Longitude</td>
+    <td>Required</td> 
+    <td>Longitude of the search area</td>
+    <td>Decimal</td>
+  </tr>
+   <tr>
+    <td>number_of_foodbanks_to_return</td>
+    <td>Required</td> 
+    <td>To limit the number of food banks that appear based on what the user has inputted [Martin to confirm max number]</td>
+    <td>Integer</td>
+  </tr>
+    </table>
+  
+<h4 id="Response">Response</h4>
+ 
+ <table style="width:100%"> 
+  <tr>
+    <th>Field</th>
+    <th>Description</th> 
+    <th>Data type</th>
+    <th>Example</th>
+  </tr>
+  <tr>
+    <td>name_of_foodbank</td>
+    <td>Food bank name</td> 
+    <td>String</td>
+    <td>"Mid Norfolk Foodbank</td>
+  </tr>
+   <tr>
+    <td>list_of_nearby_foodbanks</td>
+    <td>List of nearby foodbanks</td> 
+    <td>Array of objects in ascending order of distance (the fields for that object are nearby_foodbank; website; items_needed) </td>
+    <td></td>
+  </tr>
+   <tr>
+    <td>nearby_foodbank</td>
+    <td>Distance from the user's location in miles</td> 
+    <td>String</td>
+    <td>"15 miles"</td>
+  </tr>
+   <tr>
+    <td>website</td>
+    <td>Food bank website</td> 
+    <td>URL</td>
+    <td>http://midnorfolk.foodbank.org.uk/</td>
+  </tr>
+   </tr>
+   <tr>
+    <td>items_needed</td>
+    <td>Food items needed</td> 
+    <td>Array[String]</td>
+    <td>“tinned fruit”,
+		“tinned riced pudding”</td>
+  </tr>
+
+</table>
+ 
+  <h4 id="Input error">Input error</h4>
+  <p>If no food banks are found an empty list will be returned.
+	If the inputs are the wrong type or if they are missing then it will return the following string: 
+<blockquote>"Please make a GET request to this endpoint with latitude, longitude, and a 'number_of_foodbanks_to_show' integer"</blockquote></p>
+	
+	</body>
+	</html>	
+	
 class individual_foodbank_information:
 	def GET(self):
 		user_data = web.input()


### PR DESCRIPTION
Big change: Added developer documentation for the foodbank API written in HTML.

Minor edit in index: 
"Foodbanks" to "food bank". 
"Foodbank" tends to be in name-form, "food bank" is officially two words. (What do you think?)

I still need to add latitude, longitude and no. of maximum number of food banks to show to the description for Endpoint 2.

Feedback welcomed but please note that this is my very first attempt at documenting an API to help me learn to code a bit more and also to practice a style of writing that is completely new to me. 